### PR TITLE
Bold styled-components property names in js.

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -20,6 +20,9 @@ atom-text-editor, atom-text-editor {
     .cursor-line {
       background-color: @syntax-gutter-background-color;
     }
+    .syntax--inside-js.syntax--css.syntax--styled .syntax--property-name {
+      font-weight: bold;
+    }
   }
 
   .gutter {


### PR DESCRIPTION
When using styled-components in my projects I wanted the property names to be bold similarly to how they are in `*.css` files.

Example:
<img width="572" alt="screen shot 2017-08-25 at 9 29 08 am" src="https://user-images.githubusercontent.com/33235/29720687-f74c3b96-8977-11e7-9ed6-67886ecb5be5.png">
